### PR TITLE
Fix courses path in SecurityConfig

### DIFF
--- a/web-application/src/main/java/uikt/project/webapplication/config/SecurityConfig.java
+++ b/web-application/src/main/java/uikt/project/webapplication/config/SecurityConfig.java
@@ -17,7 +17,7 @@ public class SecurityConfig  {
         http
                 .csrf()
                 .disable()
-                .authorizeHttpRequests(authorize -> authorize.requestMatchers("/", "/home", "/login", "/register","courses","/images/**").permitAll())
+                .authorizeHttpRequests(authorize -> authorize.requestMatchers("/", "/home", "/login", "/register","/courses","/images/**").permitAll())
                 //.authorizeHttpRequests(authorize -> authorize.antMatchers("/images/**").permitAll())
                 .authorizeHttpRequests(authorize -> authorize.requestMatchers("/admin/**").hasRole("ADMIN"))
                 .logout(logout -> logout.logoutUrl("/logout").logoutSuccessUrl("/login"))


### PR DESCRIPTION
## Summary
- fix request matcher path for `/courses`

## Testing
- `mvn -q test` *(fails: command not found)*
- `sh mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684006d36388832c8b4c035ee01a430a