### PR TITLE
Fix package path typo for course service interface

### DIFF
--- a/web-application/src/main/java/uikt/project/webapplication/service/impl/CourseService.java
+++ b/web-application/src/main/java/uikt/project/webapplication/service/impl/CourseService.java
@@ -8,7 +8,7 @@ import uikt.project.webapplication.model.exceptions.ResourceNotFoundException;
 import uikt.project.webapplication.repository.AdministratorRepository;
 import uikt.project.webapplication.repository.CourseRepository;
 import uikt.project.webapplication.repository.InstructorRepository;
-import uikt.project.webapplication.service.inteface.ICourseService;
+import uikt.project.webapplication.service.interfaces.ICourseService;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/web-application/src/main/java/uikt/project/webapplication/service/interfaces/ICourseService.java
+++ b/web-application/src/main/java/uikt/project/webapplication/service/interfaces/ICourseService.java
@@ -1,4 +1,4 @@
-package uikt.project.webapplication.service.inteface;
+package uikt.project.webapplication.service.interfaces;
 
 import uikt.project.webapplication.model.entities.courses.Course;
 

--- a/web-application/src/main/java/uikt/project/webapplication/web/controller/CourseController.java
+++ b/web-application/src/main/java/uikt/project/webapplication/web/controller/CourseController.java
@@ -7,7 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import uikt.project.webapplication.model.entities.courses.Course;
-import uikt.project.webapplication.service.inteface.ICourseService;
+import uikt.project.webapplication.service.interfaces.ICourseService;
 
 import java.io.IOException;
 import java.time.LocalDate;


### PR DESCRIPTION
## Summary
- fix `uikt.project.webapplication.service.inteface` typo by moving `ICourseService`
- update CourseService and CourseController imports

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.0.5)*

------
https://chatgpt.com/codex/tasks/task_e_686597b6d830832c8db90aa05f6c7e1c